### PR TITLE
Fix 'unknown unknowns' being highlighted on first page load

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -3,6 +3,7 @@
 body{
 	font-family: 'Open Sans', sans-serif;
 	line-height: 28px;
+	position: relative;
 }
 
 a:hover{

--- a/findings/home.html
+++ b/findings/home.html
@@ -29,7 +29,7 @@
 		</nav>
 
 	</div>
-	<div class="col" data-spy="scroll" data-target="#top10"  data-offset="0">
+	<div class="col">
 		{% for vuln in vulnList %}
 		{{vuln[1]}}
 		{% endfor %}

--- a/findings/layout.html
+++ b/findings/layout.html
@@ -32,7 +32,7 @@
 	<meta name="msapplication-TileImage" content="favicon/ms-icon-144x144.png">
 	<meta name="theme-color" content="#ffffff">
 </head>
-<body>
+<body data-spy="scroll" data-target="#top10">
 
 	<!-- navbar -->
 	<nav class="navbar navbar-expand-lg real navbar-light" style="margin-bottom:20px;">
@@ -151,10 +151,6 @@
 	<script>
 		// hljs.highlighting
 		hljs.initHighlightingOnLoad();
-		// bootstrap.scrollspy
-		$(document).ready( () => {
-			$('body').scrollspy({ target: '#top10' });
-		})
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Scrollspy was being initialized twice, once with data attributes in an
inner div, once with javascript in the body. The docs suggest it should
be in the body, so this removes the javascript and moves the data
attributes to the body.

This also removes data-offset="0" to use the default value of 10, which
is needed when using the body. It also adds 'position: relative' to the
body because the docs say it's required, but it doesn't seem to do
anything in my browser.

----

I didn't touch anything in `dist/` other than the css which doesn't exist elsewhere. It sounds like the sort of thing that should maybe be in gitignore. I'll just let you decide what the right thing to do is.