### PR TITLE
Added Etherpot link

### DIFF
--- a/findings/unchecked_low_level_calls.html
+++ b/findings/unchecked_low_level_calls.html
@@ -17,7 +17,7 @@
 		<p><strong>Real World Impact</strong>:</p>
 		<ul>
 			<li><a href="https://www.kingoftheether.com/postmortem.html" target="_blank">King of the Ether</a></li>
-			<li><a href="">Etherpot</a></li>
+			<li><a href="https://web.archive.org/web/20180725200600/http://aakilfernandes.github.io/blockhashes-are-only-good-for-256-blocks/" target="_blank">Etherpot</a></li>
 		</ul>
 		<!-- example scenario -->
 <!--		<p><strong>Example</strong>:</p>

--- a/findings/unchecked_low_level_calls.html
+++ b/findings/unchecked_low_level_calls.html
@@ -17,7 +17,7 @@
 		<p><strong>Real World Impact</strong>:</p>
 		<ul>
 			<li><a href="https://www.kingoftheether.com/postmortem.html" target="_blank">King of the Ether</a></li>
-			<li><a href="https://web.archive.org/web/20180725200600/http://aakilfernandes.github.io/blockhashes-are-only-good-for-256-blocks/" target="_blank">Etherpot</a></li>
+			<li><a href="http://aakilfernandes.github.io/blockhashes-are-only-good-for-256-blocks" target="_blank">Etherpot</a></li>
 		</ul>
 		<!-- example scenario -->
 <!--		<p><strong>Example</strong>:</p>


### PR DESCRIPTION
Added a missing link to the Etherpot vulnerability description. The original blog post is gone so I linked to archive.org.