### PR TITLE
Update broken links to blog.golemproject.net

### DIFF
--- a/findings/short_addresses.html
+++ b/findings/short_addresses.html
@@ -25,14 +25,14 @@
 		  <tbody>
 		    <tr>
 		      <th scope="row">April 6, 2017</th>
-		      <td><a href="https://blog.golemproject.net/how-to-find-10m-by-just-reading-blockchain-6ae9d39fcd95">How to Find $10M Just by Reading the Blockchain</a></td>
+		      <td><a href="https://medium.com/golem-project/how-to-find-10m-by-just-reading-blockchain-6ae9d39fcd95">How to Find $10M Just by Reading the Blockchain</a></td>
 		    </tr>
 		  </tbody>
 		</table>
 		<!-- real world impact -->
 		<p><strong>Real World Impact</strong>:</p>
 		<ul>
-			<li><a href="https://blog.golemproject.net/how-to-find-10m-by-just-reading-blockchain-6ae9d39fcd95" target="_blank">unknown exchange(s)</a></li>
+			<li><a href="https://medium.com/golem-project/how-to-find-10m-by-just-reading-blockchain-6ae9d39fcd95" target="_blank">unknown exchange(s)</a></li>
 		</ul>
 		<!-- example scenario -->
 		<p><strong>Example</strong>:</p>


### PR DESCRIPTION
Apparently, the blog can no longer be reached at https://blog.golemproject.net, but still via https://medium.com/golem-project/